### PR TITLE
Refactor Pericope class architecture for better separation of concerns

### DIFF
--- a/ai/prompts/1-review.md
+++ b/ai/prompts/1-review.md
@@ -1,0 +1,164 @@
+# In-Depth Review: Pericope Class Architecture
+
+## 1. Pericope Class Data Properties
+
+The `Pericope` class manages the following core data properties:
+
+### Primary Data Properties
+- **`@book`** (Book): The biblical book reference (e.g., Genesis, Matthew)
+- **`@ranges`** (Array): Collection of verse ranges, each containing:
+  - `:start_chapter` - Starting chapter number
+  - `:start_verse` - Starting verse number  
+  - `:end_chapter` - Ending chapter number
+  - `:end_verse` - Ending verse number
+- **`@versification`** (Object): Versification system (optional, for handling different Bible versions)
+- **`@math_operations`** (MathOperations): Delegate object for mathematical operations
+
+### Derived Properties (computed from core data)
+- Verse count, chapter count, chapter list
+- First verse, last verse
+- Validation state (valid?, empty?, single_verse?, etc.)
+
+## 2. Methods That Must Access Core Data
+
+The following methods require direct access to the core data properties:
+
+### Data Access Methods (Lines 84-159)
+- `valid?` - Validates @book and @ranges
+- `empty?` - Checks if @ranges is empty
+- `single_verse?` - Examines @ranges structure
+- `single_chapter?` - Analyzes @ranges for chapter spans
+- `spans_chapters?` - Checks @ranges for cross-chapter spans
+- `verse_count` - Counts verses across @ranges
+- `chapter_count` - Counts unique chapters in @ranges
+- `first_verse` / `last_verse` - Finds extremes in @ranges
+
+### Core Functionality Methods
+- `initialize` - Sets @book, @ranges, @versification
+- `to_s` - Formats @book and @ranges as string
+- `to_a` - Converts @ranges to VerseRef array
+- `==` - Compares @book and @ranges
+
+### Parsing Methods (Lines 244-342)
+- `parse_reference` - Populates @book and @ranges
+- `parse_ranges` - Processes range text into @ranges
+- `ranges_to_string` - Formats @ranges for output
+
+## 3. Methods That Could Operate Statically
+
+The following methods could be refactored to accept a Pericope as a parameter and operate on its public properties:
+
+### Text Processing Methods (Lines 22-47)
+- `self.parse(text, versification)` - Could be moved to a TextProcessor class
+- `self.split(text, versification)` - Could be moved to a TextProcessor class
+
+### Mathematical Operations (Lines 162-240)
+All mathematical operations are already delegated to MathOperations and could be static:
+- `verses_in_chapter`, `chapters_in_range`, `density`, `gaps`, `continuous_ranges`
+- `intersects?`, `contains?`, `adjacent_to?`, `precedes?`, `follows?`
+- `union`, `intersection`, `subtract`, `complement`, `normalize`, `expand`, `contract`
+
+## 4. MathOperations Analysis
+
+### Confirmation: All Functions Operate on Passed Pericope
+✅ **CONFIRMED**: All functions in `MathOperations` operate on the Pericope passed during initialization (`@pericope`). The class follows proper delegation patterns and does not maintain independent state.
+
+### Proposed Refactoring: Split into MathOperations and SetOperations
+
+#### MathOperations Class (Lines 13-82)
+**Purpose**: Mathematical analysis and calculations
+```ruby
+class MathOperations
+  # Analysis methods
+  def verses_in_chapter(pericope, chapter)
+  def chapters_in_range(pericope)
+  def density(pericope)
+  def gaps(pericope)
+  def continuous_ranges(pericope)
+  
+  # Comparison methods  
+  def intersects?(pericope, other)
+  def contains?(pericope, other)
+  def adjacent_to?(pericope, other)
+  def precedes?(pericope, other)
+  def follows?(pericope, other)
+end
+```
+
+#### SetOperations Class (Lines 135-198)
+**Purpose**: Set theory operations that create new Pericopes
+```ruby
+class SetOperations
+  # Set operations
+  def union(pericope, other)
+  def intersection(pericope, other)
+  def subtract(pericope, other)
+  def complement(pericope, scope = nil)
+  
+  # Transformation operations
+  def normalize(pericope)
+  def expand(pericope, verses_before = 0, verses_after = 0)
+  def contract(pericope, verses_from_start = 0, verses_from_end = 0)
+end
+```
+
+## 5. Pericope Class Text Processing Refactoring
+
+### Proposed TextProcessor Class
+The parsing and text-related functions could be extracted into a separate class:
+
+```ruby
+class TextProcessor
+  def self.parse(text, versification = nil)
+    # Extract from Pericope.parse (lines 22-38)
+  end
+  
+  def self.split(text, versification = nil)
+    # Extract from Pericope.split (lines 41-47)
+  end
+  
+  def self.format_pericope(pericope, format = :canonical)
+    # Extract from Pericope#to_s (lines 50-59)
+  end
+  
+  private
+  
+  def self.parse_reference(reference_string, versification = nil)
+    # Extract parsing logic (lines 244-263)
+  end
+end
+```
+
+### Benefits of Refactoring
+1. **Single Responsibility**: Each class has a focused purpose
+2. **Testability**: Easier to unit test individual components
+3. **Reusability**: Text processing can be used independently
+4. **Maintainability**: Changes to parsing logic don't affect core Pericope class
+
+### Recommended Pericope Class Structure After Refactoring
+```ruby
+class Pericope
+  attr_reader :book, :ranges, :versification
+  
+  # Core data management
+  def initialize(reference_string, versification = nil)
+  def valid?
+  def to_a
+  def ==
+  
+  # Delegate to specialized classes
+  def to_s(format = :canonical)
+    TextProcessor.format_pericope(self, format)
+  end
+  
+  def union(other)
+    SetOperations.union(self, other)
+  end
+  
+  def density
+    MathOperations.density(self)
+  end
+end
+```
+
+This architecture would create a cleaner separation of concerns while maintaining the existing public API.

--- a/lib/pericope/math.rb
+++ b/lib/pericope/math.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require "set"
+require_relative "verse_ref"
+
+module Pericope
+  # Mathematical operations for Pericope objects
+  # All methods are static and operate on Pericope objects passed as parameters
+  module Math
+    class << self
+      # Advanced mathematical operations
+      def verses_in_chapter(pericope, chapter)
+        return 0 unless chapter.positive? && chapter <= pericope.book.chapter_count
+
+        count = 0
+        pericope.ranges.each do |range|
+          next unless chapter.between?(range[:start_chapter], range[:end_chapter])
+
+          start_verse = chapter == range[:start_chapter] ? range[:start_verse] : 1
+          end_verse = chapter == range[:end_chapter] ? range[:end_verse] : pericope.book.verse_count(chapter)
+
+          count += (end_verse - start_verse + 1)
+        end
+        count
+      end
+
+      def chapters_in_range(pericope)
+        result = {}
+        pericope.ranges.each do |range|
+          (range[:start_chapter]..range[:end_chapter]).each do |chapter|
+            result[chapter] ||= []
+            start_verse = chapter == range[:start_chapter] ? range[:start_verse] : 1
+            end_verse = chapter == range[:end_chapter] ? range[:end_verse] : pericope.book.verse_count(chapter)
+
+            (start_verse..end_verse).each do |verse|
+              result[chapter] << verse unless result[chapter].include?(verse)
+            end
+          end
+        end
+        result.each_value(&:sort!)
+        result
+      end
+
+      def density(pericope)
+        return 0.0 if pericope.ranges.empty?
+
+        total_possible = 0
+        included_verses = pericope.verse_count
+
+        pericope.chapter_list.each do |chapter|
+          total_possible += pericope.book.verse_count(chapter)
+        end
+
+        return 0.0 if total_possible.zero?
+
+        included_verses.to_f / total_possible
+      end
+
+      def gaps(pericope)
+        return [] if pericope.ranges.empty? || pericope.single_verse?
+
+        all_verses = collect_all_verses(pericope)
+        first = pericope.first_verse
+        last = pericope.last_verse
+        return [] unless first && last
+
+        possible_verses = generate_possible_verses(first, last)
+        possible_verses.reject { |verse| all_verses.include?(verse) }
+      end
+
+      def continuous_ranges(pericope)
+        return [] if pericope.ranges.empty?
+
+        verses = pericope.to_a.sort
+        return [pericope] if verses.length <= 1
+
+        continuous_groups = group_consecutive_verses(verses)
+        continuous_groups.map { |group| create_pericope_from_group(group, pericope.book) }
+      end
+
+      # Comparison methods
+      def intersects?(pericope, other)
+        return false unless valid_comparison_target?(pericope, other)
+
+        my_verses = ::Set.new(pericope.to_a)
+        other_verses = ::Set.new(other.to_a)
+        !(my_verses & other_verses).empty?
+      end
+
+      def contains?(pericope, other)
+        return false unless valid_comparison_target?(pericope, other)
+
+        my_verses = ::Set.new(pericope.to_a)
+        other_verses = ::Set.new(other.to_a)
+        other_verses.subset?(my_verses)
+      end
+
+      def adjacent_to?(pericope, other)
+        return false unless valid_comparison_target?(pericope, other)
+
+        my_last = pericope.last_verse
+        other_first = other.first_verse
+        my_first = pericope.first_verse
+        other_last = other.last_verse
+
+        return false unless my_last && other_first && my_first && other_last
+
+        (my_last.next_verse == other_first) || (other_last.next_verse == my_first)
+      end
+
+      def precedes?(pericope, other)
+        return false unless valid_comparison_target?(pericope, other)
+
+        my_last = pericope.last_verse
+        other_first = other.first_verse
+
+        return false unless my_last && other_first
+
+        my_last < other_first
+      end
+
+      def follows?(pericope, other)
+        return false unless valid_comparison_target?(pericope, other)
+
+        my_first = pericope.first_verse
+        other_last = other.last_verse
+
+        return false unless my_first && other_last
+
+        my_first > other_last
+      end
+
+      private
+
+      def valid_comparison_target?(pericope, other)
+        other.is_a?(Pericope) && pericope.book == other.book
+      end
+
+      def collect_all_verses(pericope)
+        all_verses = ::Set.new
+        pericope.ranges.each do |range|
+          (range[:start_chapter]..range[:end_chapter]).each do |chapter|
+            start_verse = chapter == range[:start_chapter] ? range[:start_verse] : 1
+            end_verse = chapter == range[:end_chapter] ? range[:end_verse] : pericope.book.verse_count(chapter)
+
+            (start_verse..end_verse).each do |verse|
+              all_verses << VerseRef.new(pericope.book, chapter, verse)
+            end
+          end
+        end
+        all_verses
+      end
+
+      def generate_possible_verses(first, last)
+        possible_verses = []
+        current = first
+        while current <= last
+          possible_verses << current
+          current = current.next_verse
+          break if current.nil? || current > last
+        end
+        possible_verses
+      end
+
+      def group_consecutive_verses(verses)
+        continuous_groups = []
+        current_group = [verses.first]
+
+        verses[1..].each do |verse|
+          if current_group.last.next_verse == verse
+            current_group << verse
+          else
+            continuous_groups << current_group
+            current_group = [verse]
+          end
+        end
+        continuous_groups << current_group
+        continuous_groups
+      end
+
+      def create_pericope_from_group(group, book)
+        return create_single_verse_pericope(group.first, book) if group.length == 1
+
+        create_range_pericope(group.first, group.last, book)
+      end
+
+      def create_single_verse_pericope(verse, book)
+        Pericope.new("#{book.code} #{verse.chapter}:#{verse.verse}")
+      end
+
+      def create_range_pericope(first_verse, last_verse, book)
+        if first_verse.chapter == last_verse.chapter
+          Pericope.new("#{book.code} #{first_verse.chapter}:#{first_verse.verse}-#{last_verse.verse}")
+        else
+          range_str = "#{first_verse.chapter}:#{first_verse.verse}-#{last_verse.chapter}:#{last_verse.verse}"
+          Pericope.new("#{book.code} #{range_str}")
+        end
+      end
+    end
+  end
+end

--- a/lib/pericope/pericope.rb
+++ b/lib/pericope/pericope.rb
@@ -4,7 +4,9 @@ require "set"
 require_relative "book"
 require_relative "verse_ref"
 require_relative "errors"
-require_relative "math_operations"
+require_relative "text_processor"
+require_relative "math"
+require_relative "set_operations"
 
 module Pericope
   # Main class for parsing and manipulating pericopes
@@ -15,47 +17,21 @@ module Pericope
       @versification = versification
       @ranges = []
       parse_reference(reference_string)
-      @math_operations = MathOperations.new(self)
     end
 
     # Parse pericopes from text
     def self.parse(text, versification = nil)
-      # Simple implementation - look for book codes followed by ranges
-      pericopes = []
-
-      # Pattern to match book codes and ranges
-      pattern = /\b([A-Z]{3}|[1-3][A-Z]{2})\s+([0-9:,-]+)/i
-
-      text.scan(pattern) do |book_code, range_text|
-        pericope = new("#{book_code} #{range_text}", versification)
-        pericopes << pericope
-      rescue PericopeError
-        # Skip invalid pericopes
-        next
-      end
-
-      pericopes
+      TextProcessor.parse(text, versification)
     end
 
     # Split text on pericopes
     def self.split(text, versification = nil)
-      pericopes = parse(text, versification)
-      return [text] if pericopes.empty?
-
-      # Simple implementation - just return the text as is for now
-      [text]
+      TextProcessor.split(text, versification)
     end
 
     # String representation
     def to_s(format = :canonical)
-      return "" if @ranges.empty?
-
-      case format
-      when :full_name
-        "#{@book.name} #{ranges_to_string}"
-      else # :canonical, :abbreviated, or any other format
-        "#{@book.code} #{ranges_to_string}"
-      end
+      TextProcessor.format_pericope(self, format)
     end
 
     # Convert to array of VerseRef objects
@@ -121,7 +97,7 @@ module Pericope
     end
 
     def chapter_count
-      chapters = Set.new
+      chapters = ::Set.new
       @ranges.each do |range|
         (range[:start_chapter]..range[:end_chapter]).each { |ch| chapters << ch }
       end
@@ -129,7 +105,7 @@ module Pericope
     end
 
     def chapter_list
-      chapters = Set.new
+      chapters = ::Set.new
       @ranges.each do |range|
         (range[:start_chapter]..range[:end_chapter]).each { |ch| chapters << ch }
       end
@@ -158,25 +134,25 @@ module Pericope
       @ranges.length
     end
 
-    # Advanced mathematical operations (Phase 3.3) - delegated to MathOperations
+    # Advanced mathematical operations (Phase 3.3) - delegated to Math module
     def verses_in_chapter(chapter)
-      @math_operations.verses_in_chapter(chapter)
+      Math.verses_in_chapter(self, chapter)
     end
 
     def chapters_in_range
-      @math_operations.chapters_in_range
+      Math.chapters_in_range(self)
     end
 
     def density
-      @math_operations.density
+      Math.density(self)
     end
 
     def gaps
-      @math_operations.gaps
+      Math.gaps(self)
     end
 
     def continuous_ranges
-      @math_operations.continuous_ranges
+      Math.continuous_ranges(self)
     end
 
     # Comparison methods (Phase 3.4)
@@ -187,11 +163,11 @@ module Pericope
     end
 
     def intersects?(other)
-      @math_operations.intersects?(other)
+      Math.intersects?(self, other)
     end
 
     def contains?(other)
-      @math_operations.contains?(other)
+      Math.contains?(self, other)
     end
 
     def overlaps?(other)
@@ -199,146 +175,52 @@ module Pericope
     end
 
     def adjacent_to?(other)
-      @math_operations.adjacent_to?(other)
+      Math.adjacent_to?(self, other)
     end
 
     def precedes?(other)
-      @math_operations.precedes?(other)
+      Math.precedes?(self, other)
     end
 
     def follows?(other)
-      @math_operations.follows?(other)
+      Math.follows?(self, other)
     end
 
-    # Set operations (Pericope Math) - delegated to MathOperations
+    # Set operations (Pericope Math) - delegated to SetOperations module
     def union(other)
-      @math_operations.union(other)
+      SetOperations.union(self, other)
     end
 
     def intersection(other)
-      @math_operations.intersection(other)
+      SetOperations.intersection(self, other)
     end
 
     def subtract(other)
-      @math_operations.subtract(other)
+      SetOperations.subtract(self, other)
     end
 
     def complement(scope = nil)
-      @math_operations.complement(scope)
+      SetOperations.complement(self, scope)
     end
 
     def normalize
-      @math_operations.normalize
+      SetOperations.normalize(self)
     end
 
     def expand(verses_before = 0, verses_after = 0)
-      @math_operations.expand(verses_before, verses_after)
+      SetOperations.expand(self, verses_before, verses_after)
     end
 
     def contract(verses_from_start = 0, verses_from_end = 0)
-      @math_operations.contract(verses_from_start, verses_from_end)
+      SetOperations.contract(self, verses_from_start, verses_from_end)
     end
 
     private
 
     def parse_reference(reference_string)
-      if reference_string.nil? || reference_string.strip.empty?
-        raise ParseError.new(reference_string,
-                             "empty reference")
-      end
-
-      # Split book from ranges
-      parts = reference_string.strip.split(/\s+/, 2)
-      raise ParseError.new(reference_string, "no book found") if parts.empty?
-
-      book_part = parts[0]
-      range_part = parts[1] || "1:1"
-
-      # Find book
-      @book = Book.find_by_name(book_part)
-      raise InvalidBookError, book_part unless @book
-
-      # Parse ranges
-      parse_ranges(range_part)
-    end
-
-    def parse_ranges(range_text)
-      # Split on commas for multiple ranges
-      range_parts = range_text.split(",").map(&:strip)
-      current_chapter = nil
-
-      range_parts.each do |part|
-        current_chapter = parse_single_range(part, current_chapter)
-      end
-    end
-
-    def parse_single_range(range_text, current_chapter = nil)
-      # Handle different range formats:
-      # "1:1" - single verse
-      # "1:1-5" - verse range in same chapter
-      # "1:1-2:5" - cross-chapter range
-      # "3" - verse in current chapter (when current_chapter is set)
-
-      if range_text.include?("-")
-        # Range
-        start_part, end_part = range_text.split("-", 2).map(&:strip)
-        start_chapter, start_verse = parse_verse_reference(start_part, current_chapter)
-
-        if end_part.include?(":")
-          # Cross-chapter range like "1:1-2:5"
-          end_chapter, end_verse = parse_verse_reference(end_part, start_chapter)
-        else
-          # Same chapter range like "1:1-5" or "5-7" (in current chapter)
-          end_chapter = start_chapter
-          end_verse = end_part.to_i
-        end
-      else
-        # Single verse
-        start_chapter, start_verse = parse_verse_reference(range_text, current_chapter)
-        end_chapter = start_chapter
-        end_verse = start_verse
-      end
-
-      @ranges << {
-        start_chapter: start_chapter,
-        start_verse: start_verse,
-        end_chapter: end_chapter,
-        end_verse: end_verse
-      }
-
-      # Return the chapter for context in next iteration
-      start_chapter
-    end
-
-    def parse_verse_reference(verse_text, current_chapter = nil)
-      if verse_text.include?(":")
-        chapter, verse = verse_text.split(":", 2).map(&:to_i)
-      elsif current_chapter
-        # If we have a current chapter context, treat this as a verse in that chapter
-        chapter = current_chapter
-        verse = verse_text.to_i
-      else
-        # Assume it's just a chapter
-        chapter = verse_text.to_i
-        verse = 1
-      end
-
-      [chapter, verse]
-    end
-
-    def ranges_to_string
-      @ranges.map do |range|
-        if range[:start_chapter] == range[:end_chapter] && range[:start_verse] == range[:end_verse]
-          # Single verse
-          "#{range[:start_chapter]}:#{range[:start_verse]}"
-        elsif range[:start_chapter] == range[:end_chapter]
-          # Same chapter range
-          "#{range[:start_chapter]}:#{range[:start_verse]}-#{range[:end_verse]}"
-        else
-          # Cross-chapter range
-          "#{range[:start_chapter]}:#{range[:start_verse]}-#{range[:end_chapter]}:#{range[:end_verse]}"
-        end
-      end.join(",")
+      result = TextProcessor.parse_reference(reference_string, @versification)
+      @book = result[:book]
+      @ranges = result[:ranges]
     end
   end
 end

--- a/lib/pericope/set_operations.rb
+++ b/lib/pericope/set_operations.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "set"
+require_relative "verse_ref"
+
+module Pericope
+  # Set operations for Pericope objects
+  # All methods are static and operate on Pericope objects passed as parameters
+  module SetOperations
+    class << self
+      # Set operations
+      def union(pericope, other)
+        return pericope unless valid_set_operation_target?(pericope, other)
+
+        combined_verses = ::Set.new(pericope.to_a) | ::Set.new(other.to_a)
+        verses_to_pericope(combined_verses.to_a.sort, pericope.book)
+      end
+
+      def intersection(pericope, other)
+        return create_empty_pericope(pericope.book) unless valid_set_operation_target?(pericope, other)
+
+        common_verses = ::Set.new(pericope.to_a) & ::Set.new(other.to_a)
+        return create_empty_pericope(pericope.book) if common_verses.empty?
+
+        verses_to_pericope(common_verses.to_a.sort, pericope.book)
+      end
+
+      def subtract(pericope, other)
+        return pericope unless valid_set_operation_target?(pericope, other)
+
+        remaining_verses = ::Set.new(pericope.to_a) - ::Set.new(other.to_a)
+        return create_empty_pericope(pericope.book) if remaining_verses.empty?
+
+        verses_to_pericope(remaining_verses.to_a.sort, pericope.book)
+      end
+
+      def complement(pericope, scope = nil)
+        scope_verses = determine_scope_verses(pericope, scope)
+        my_verses = ::Set.new(pericope.to_a)
+        complement_verses = scope_verses - my_verses
+        return create_empty_pericope(pericope.book) if complement_verses.empty?
+
+        verses_to_pericope(complement_verses.to_a.sort, pericope.book)
+      end
+
+      def normalize(pericope)
+        return pericope if pericope.ranges.empty?
+
+        verses = pericope.to_a.uniq.sort
+        verses_to_pericope(verses, pericope.book)
+      end
+
+      def expand(pericope, verses_before = 0, verses_after = 0)
+        return pericope if verses_before.zero? && verses_after.zero?
+
+        expanded_verses = ::Set.new(pericope.to_a)
+        add_verses_before(expanded_verses, pericope.first_verse, verses_before)
+        add_verses_after(expanded_verses, pericope.last_verse, verses_after)
+
+        verses_to_pericope(expanded_verses.to_a.sort, pericope.book)
+      end
+
+      def contract(pericope, verses_from_start = 0, verses_from_end = 0)
+        verses = pericope.to_a.sort
+        return create_empty_pericope(pericope.book) if verses.length <= (verses_from_start + verses_from_end)
+
+        start_index = verses_from_start
+        end_index = verses.length - verses_from_end - 1
+
+        return create_empty_pericope(pericope.book) if start_index > end_index
+
+        contracted_verses = verses[start_index..end_index]
+        verses_to_pericope(contracted_verses, pericope.book)
+      end
+
+      private
+
+      def valid_set_operation_target?(pericope, other)
+        other.is_a?(Pericope) && pericope.book == other.book
+      end
+
+      def determine_scope_verses(pericope, scope)
+        if scope.is_a?(Pericope) && scope.book == pericope.book
+          ::Set.new(scope.to_a)
+        else
+          generate_all_book_verses(pericope.book)
+        end
+      end
+
+      def generate_all_book_verses(book)
+        all_verses = []
+        (1..book.chapter_count).each do |chapter|
+          (1..book.verse_count(chapter)).each do |verse|
+            all_verses << VerseRef.new(book, chapter, verse)
+          end
+        end
+        ::Set.new(all_verses)
+      end
+
+      def add_verses_before(expanded_verses, first_verse, verses_before)
+        return unless verses_before.positive? && first_verse
+
+        current = first_verse
+        verses_before.times do
+          prev = current&.previous_verse
+          break unless prev
+
+          expanded_verses << prev
+          current = prev
+        end
+      end
+
+      def add_verses_after(expanded_verses, last_verse, verses_after)
+        return unless verses_after.positive? && last_verse
+
+        current = last_verse
+        verses_after.times do
+          next_v = current&.next_verse
+          break unless next_v
+
+          expanded_verses << next_v
+          current = next_v
+        end
+      end
+
+      def create_empty_pericope(book)
+        empty_pericope = Pericope.new("#{book.code} 1:1")
+        empty_pericope.instance_variable_set(:@ranges, [])
+        empty_pericope
+      end
+
+      def verses_to_pericope(verses, book)
+        return create_empty_pericope(book) if verses.empty?
+
+        ranges = build_ranges_from_verses(verses)
+        new_pericope = Pericope.new("#{book.code} 1:1")
+        new_pericope.instance_variable_set(:@ranges, ranges)
+        new_pericope
+      end
+
+      def build_ranges_from_verses(verses)
+        ranges = []
+        current_start = verses.first
+        current_end = verses.first
+
+        verses[1..].each do |verse|
+          if current_end.next_verse == verse
+            current_end = verse
+          else
+            ranges << build_range_hash(current_start, current_end)
+            current_start = verse
+            current_end = verse
+          end
+        end
+
+        ranges << build_range_hash(current_start, current_end)
+        ranges
+      end
+
+      def build_range_hash(start_verse, end_verse)
+        {
+          start_chapter: start_verse.chapter,
+          start_verse: start_verse.verse,
+          end_chapter: end_verse.chapter,
+          end_verse: end_verse.verse
+        }
+      end
+    end
+  end
+end

--- a/lib/pericope/text_processor.rb
+++ b/lib/pericope/text_processor.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require_relative "book"
+require_relative "errors"
+
+module Pericope
+  # Text processing operations for Pericope objects
+  # All methods are static and handle parsing and formatting
+  class TextProcessor
+    class << self
+      # Parse pericopes from text
+      def parse(text, versification = nil)
+        # Simple implementation - look for book codes followed by ranges
+        pericopes = []
+
+        # Pattern to match book codes and ranges
+        pattern = /\b([A-Z]{3}|[1-3][A-Z]{2})\s+([0-9:,-]+)/i
+
+        text.scan(pattern) do |book_code, range_text|
+          pericope = Pericope.new("#{book_code} #{range_text}", versification)
+          pericopes << pericope
+        rescue PericopeError
+          # Skip invalid pericopes
+          next
+        end
+
+        pericopes
+      end
+
+      # Split text on pericopes
+      def split(text, versification = nil)
+        pericopes = parse(text, versification)
+        return [text] if pericopes.empty?
+
+        # Simple implementation - just return the text as is for now
+        [text]
+      end
+
+      # Format a pericope as string
+      def format_pericope(pericope, format = :canonical)
+        return "" if pericope.ranges.empty?
+
+        case format
+        when :full_name
+          "#{pericope.book.name} #{format_ranges(pericope.ranges)}"
+        else # :canonical, :abbreviated, or any other format
+          "#{pericope.book.code} #{format_ranges(pericope.ranges)}"
+        end
+      end
+
+      # Parse a reference string into book and ranges
+      def parse_reference(reference_string, _versification = nil)
+        if reference_string.nil? || reference_string.strip.empty?
+          raise ParseError.new(reference_string, "empty reference")
+        end
+
+        # Split book from ranges
+        parts = reference_string.strip.split(/\s+/, 2)
+        raise ParseError.new(reference_string, "no book found") if parts.empty?
+
+        book_part = parts[0]
+        range_part = parts[1] || "1:1"
+
+        # Find book
+        book = Book.find_by_name(book_part)
+        raise InvalidBookError, book_part unless book
+
+        # Parse ranges
+        ranges = parse_ranges(range_part, book)
+
+        { book: book, ranges: ranges }
+      end
+
+      private
+
+      def format_ranges(ranges)
+        ranges.map do |range|
+          if range[:start_chapter] == range[:end_chapter] && range[:start_verse] == range[:end_verse]
+            # Single verse
+            "#{range[:start_chapter]}:#{range[:start_verse]}"
+          elsif range[:start_chapter] == range[:end_chapter]
+            # Same chapter range
+            "#{range[:start_chapter]}:#{range[:start_verse]}-#{range[:end_verse]}"
+          else
+            # Cross-chapter range
+            "#{range[:start_chapter]}:#{range[:start_verse]}-#{range[:end_chapter]}:#{range[:end_verse]}"
+          end
+        end.join(",")
+      end
+
+      def parse_ranges(range_text, book)
+        ranges = []
+        # Split on commas for multiple ranges
+        range_parts = range_text.split(",").map(&:strip)
+        current_chapter = nil
+
+        range_parts.each do |part|
+          current_chapter = parse_single_range(part, current_chapter, book, ranges)
+        end
+
+        ranges
+      end
+
+      def parse_single_range(range_text, current_chapter, _book, ranges)
+        # Handle different range formats:
+        # "1:1" - single verse
+        # "1:1-5" - verse range in same chapter
+        # "1:1-2:5" - cross-chapter range
+        # "3" - verse in current chapter (when current_chapter is set)
+
+        if range_text.include?("-")
+          # Range
+          start_part, end_part = range_text.split("-", 2).map(&:strip)
+          start_chapter, start_verse = parse_verse_reference(start_part, current_chapter)
+
+          if end_part.include?(":")
+            # Cross-chapter range like "1:1-2:5"
+            end_chapter, end_verse = parse_verse_reference(end_part, start_chapter)
+          else
+            # Same chapter range like "1:1-5" or "5-7" (in current chapter)
+            end_chapter = start_chapter
+            end_verse = end_part.to_i
+          end
+        else
+          # Single verse
+          start_chapter, start_verse = parse_verse_reference(range_text, current_chapter)
+          end_chapter = start_chapter
+          end_verse = start_verse
+        end
+
+        ranges << {
+          start_chapter: start_chapter,
+          start_verse: start_verse,
+          end_chapter: end_chapter,
+          end_verse: end_verse
+        }
+
+        # Return the chapter for context in next iteration
+        start_chapter
+      end
+
+      def parse_verse_reference(verse_text, current_chapter = nil)
+        if verse_text.include?(":")
+          chapter, verse = verse_text.split(":", 2).map(&:to_i)
+        elsif current_chapter
+          # If we have a current chapter context, treat this as a verse in that chapter
+          chapter = current_chapter
+          verse = verse_text.to_i
+        else
+          # Assume it's just a chapter
+          chapter = verse_text.to_i
+          verse = 1
+        end
+
+        [chapter, verse]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Overview

This PR refactors the Pericope class architecture to improve separation of concerns and modularity, as outlined in the comprehensive review in `ai/prompts/1-review.md`.

## Changes Made

### 1. **Extracted Mathematical Operations** → `Pericope::Math`
- Created new `lib/pericope/math.rb` with static methods
- Moved all mathematical analysis and comparison operations
- Methods: `verses_in_chapter`, `chapters_in_range`, `density`, `gaps`, `continuous_ranges`, `intersects?`, `contains?`, `adjacent_to?`, `precedes?`, `follows?`

### 2. **Extracted Set Operations** → `Pericope::SetOperations`
- Created new `lib/pericope/set_operations.rb` with static methods
- Moved all set theory operations that create new Pericopes
- Methods: `union`, `intersection`, `subtract`, `complement`, `normalize`, `expand`, `contract`

### 3. **Extracted Text Processing** → `Pericope::TextProcessor`
- Created new `lib/pericope/text_processor.rb` with static methods
- Moved parsing and formatting functionality
- Methods: `parse`, `split`, `format_pericope`, `parse_reference`

### 4. **Simplified Pericope Class**
- Removed `@math_operations` delegation object
- Updated all methods to use new static module APIs
- Maintained complete backward compatibility with existing public API
- Reduced class complexity and improved testability

## Benefits

- **Single Responsibility**: Each module has a focused purpose
- **Testability**: Easier to unit test individual components
- **Reusability**: Static methods can be used independently
- **Maintainability**: Changes to specific functionality are isolated
- **Performance**: Eliminates delegation overhead

## Testing

- ✅ All 172 existing tests pass
- ✅ RuboCop style checks pass
- ✅ Backward compatibility maintained
- ✅ No breaking changes to public API

## Usage Examples

The public API remains unchanged:
```ruby
pericope = Pericope::Pericope.new("GEN 1:1-10")
pericope.density  # Still works as before
pericope.union(other)  # Still works as before
```

But now users can also call operations statically:
```ruby
Pericope::Math.density(pericope)
Pericope::SetOperations.union(pericope, other)
Pericope::TextProcessor.parse(text)
```

This refactoring sets up the codebase for future enhancements while maintaining full compatibility with existing code.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author